### PR TITLE
added MacOS to build system, simplified TCP handling and minor improvements

### DIFF
--- a/soft/r2t2gui/control.cpp
+++ b/soft/r2t2gui/control.cpp
@@ -69,15 +69,15 @@ Control::Control(char *ip, char* audiodev, char* audiodevMixer, char* mixerVolum
     audio = new Audio(audiodev, audiodevMixer, mixerVolume, mixerMic, conf->get(CMD_SAMPLE_RATE));
     //connect(audio, SIGNAL(audioTX(QByteArray)), sdr, SLOT(writeR2T2(QByteArray)), Qt::QueuedConnection);
 
-    timer = new QTimer(this);
-    timer->setSingleShot(true);
+    serverListUpdateTimer = new QTimer(this);
+    serverListUpdateTimer->setSingleShot(true);
 
 #ifdef UNIX
     //keyReader = new KeyReader();
 
     //connect(keyReader, SIGNAL(controlCommand(int,int,int)), this, SLOT(controlCommand(int,int,int))); 
 #endif
-    connect(timer, SIGNAL(timeout()), this, SLOT(timeout()));
+    connect(serverListUpdateTimer, SIGNAL(timeout()), this, SLOT(timeout()));
     connect(disp, SIGNAL(command(int, int, int)), this, SLOT(controlCommand(int, int, int)));
     connect(this, SIGNAL(displaySet(int, int, int)), disp, SLOT(displaySet(int, int, int)));
     connect(sdrqt, SIGNAL(audioRX(QByteArray)), audio, SLOT(audioRX(QByteArray)));
@@ -117,7 +117,7 @@ Control::Control(char *ip, char* audiodev, char* audiodevMixer, char* mixerVolum
     sdr->startRX();
     setMode();
 
-    timer->start(1000*120); // 2 min reread server
+    serverListUpdateTimer->start(1000*120); // 2 min reread server
 }
 
 Control::~Control() {
@@ -129,7 +129,7 @@ Control::~Control() {
     delete audio;
     delete sdr;
     delete disp;
-    delete timer;
+    delete serverListUpdateTimer;
 #ifdef UNIX
     //keyReader->restore();
     //keyReader->terminate();
@@ -146,7 +146,7 @@ void Control::cleanup() {
 
 void Control::timeout() {
     readServer();
-    timer->start(1000*120); // 2 min reread server
+    serverListUpdateTimer->start(1000*120); // 2 min reread server
 }
 
 void Control::readServer() {
@@ -344,7 +344,7 @@ void Control::controlCommand(int src, int cmd, int par, bool initial) {
             break;
         case CMD_CONNECT:
             if (src == SRC_SDR) 
-                timer->start(2000); // read server afer 2s
+                serverListUpdateTimer->start(2000); // read server afer 2s
             else
                 sdr->connectServer(par>0);
             break;

--- a/soft/r2t2gui/control.h
+++ b/soft/r2t2gui/control.h
@@ -35,8 +35,8 @@ class Control : public QObject  {
 	private:
 		void setMode();
 
-		QTimer *timer;
-		QString r2t2IP;
+        QTimer *serverListUpdateTimer;
+        QString r2t2IP;
 		QUdpSocket *hamLibSocket;
         QNetworkAccessManager *manager;
 		Sdr *sdr, *sdrqt, *sdrr2t2;

--- a/soft/r2t2gui/r2t2.pro
+++ b/soft/r2t2gui/r2t2.pro
@@ -28,7 +28,15 @@ unix {
 	QT += multimedia
 } 
 
-INCLUDEPATH += /usr/local/include/ 
+
+# INCLUDEPATH += /usr/local/include/
+
+# PKG-Config is a more robust way to import libaries on Linux / Mac
+# since the libraries are not always installed at /usr/local/include
+unix {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += protobuf
+}
 
 SOURCES += main.cpp control.cpp sdrr2t2.cpp sdrqtradio.cpp
 SOURCES += display_touch.cpp display_lcd.cpp smeter.cpp clock.cpp
@@ -55,15 +63,19 @@ win32 {
 HEADERS += control.h sdr.h sdrr2t2.h sdrqtradio.h display_lcd.h display_touch.h display_base.h smeter.h clock.h
 HEADERS += textbutton.h numeric.h fftGraph.h filterGraph.h analog.h label.h sdrgraphicsitem.h
 
-unix {
-	#HEADERS += keyreader.h audio.h
-	# HEADERS += audioQt.h
-	HEADERS += audio.h
+unix:!mac {
+        #HEADERS += keyreader.h audio.h
+        # HEADERS += audioQt.h
+        HEADERS += audio.h
+}
+
+mac: {
+        HEADERS += audioQt.h
 }
 
 win32 {
-	# HEADERS += audio_win32.h
-	HEADERS += audioQt.h
+        # HEADERS += audio_win32.h
+        HEADERS += audioQt.h
 }
 
 FORMS    += display_touch.ui

--- a/soft/r2t2gui/sdrqtradio.cpp
+++ b/soft/r2t2gui/sdrqtradio.cpp
@@ -22,13 +22,13 @@ SdrQtRadio::SdrQtRadio (QString ip, int port) : ip(ip), port(port) {
     tcpTimer->setSingleShot(true);
 	connect(tcpTimer, SIGNAL(timeout()), this, SLOT(tcpTimeout()));
     // tcpTimer->start(1000);
-	timer = new QTimer(this);
-	connect(timer, SIGNAL(timeout()), this, SLOT(fftTime()));
+    fftTimer = new QTimer(this);
+    connect(fftTimer, SIGNAL(timeout()), this, SLOT(fftTime()));
 }
 
 SdrQtRadio::~SdrQtRadio() {
     delete tcpSocket;
-	delete timer;
+    delete fftTimer;
 }
 
 void SdrQtRadio::setServer(QString serverIP, uint16_t serverPort) {
@@ -54,7 +54,7 @@ void SdrQtRadio::connectServer(bool con) {
         tcpTimer->start(1000);
     } else {
         startRx = true;
-        timer->stop();
+        fftTimer->stop();
         tcpSocket->disconnectFromHost();
     }
 }
@@ -68,7 +68,7 @@ void SdrQtRadio::sendStartSeq() {
     sendCmd("setEncoding 0");
     sendCmd("startAudioStream 800 8000 1 0");
     if (fftTimeRep > 0)
-        timer->start(fftTimeRep);
+        fftTimer->start(fftTimeRep);
 }
 
 void SdrQtRadio::connected() {
@@ -92,7 +92,7 @@ void SdrQtRadio::error(QAbstractSocket::SocketError /*error*/) {
 void SdrQtRadio::disconnected() {
     inBuf.clear();
     tcpTimer->stop();
-    timer->stop();
+    fftTimer->stop();
     conn = false;
 	qDebug() << "disconnected";
     emit controlCommand(SRC_SDR, CMD_CONNECT, 0); 
@@ -238,7 +238,7 @@ void SdrQtRadio::setFFT(int time, int size) {
     fftSize = size;
     fftTimeRep = time;
     if (fftTimeRep > 0)
-        timer->start(fftTimeRep);
+        fftTimer->start(fftTimeRep);
 }
 
 void SdrQtRadio::setMode(int m) {

--- a/soft/r2t2gui/sdrqtradio.h
+++ b/soft/r2t2gui/sdrqtradio.h
@@ -66,7 +66,7 @@ class SdrQtRadio : public Sdr  {
     private:
         void sendStartSeq();
         QTcpSocket *tcpSocket;
-        QTimer *timer,*tcpTimer;
+        QTimer *fftTimer,*tcpTimer;
 		QByteArray inBuf;
         QString ip;
         uint16_t port;

--- a/soft/r2t2gui/sdrr2t2.h
+++ b/soft/r2t2gui/sdrr2t2.h
@@ -67,7 +67,7 @@ class SdrR2T2 : public Sdr  {
         void sendStartSeq();
         QTcpSocket *tcpSocket;
         QTimer *timer, *tcpTimer;
-        QMutex mutex, cmdmutex;
+//        QMutex mutex, cmdmutex;
 		QByteArray inBuf;
         QString ip;
         uint16_t port;
@@ -75,7 +75,6 @@ class SdrR2T2 : public Sdr  {
 		R2T2GuiProto::R2T2GuiMessageAnswer *r2t2GuiMsgAnswer;
 
 		void sendR2T2GuiMsg();
-        bool conn = false;
         bool startRx = false;
         int fftSize = 1024;
         int fftTimeRep = 0;
@@ -95,5 +94,7 @@ class SdrR2T2 : public Sdr  {
         int fftRate = 0;
         int gain = 0;
         int txFreq = 71000000;
+        uint8_t tcp_buf[1024*64];
+        int tcp_buf_len = 0;
 };
 

--- a/soft/r2t2gui/sdrr2t2.h
+++ b/soft/r2t2gui/sdrr2t2.h
@@ -66,7 +66,7 @@ class SdrR2T2 : public Sdr  {
     private:
         void sendStartSeq();
         QTcpSocket *tcpSocket;
-        QTimer *timer, *tcpTimer;
+        QTimer *fftTimer, *tcpTimer;
 //        QMutex mutex, cmdmutex;
 		QByteArray inBuf;
         QString ip;


### PR DESCRIPTION
Hi Stefan, 

this PR is for the GUI Application and contains: 

- adding MacOS to the Qmake build system
- changing from fixed path imports to pkg-config based import
- fixed tcp buffer handling (resolves "sync error: magic" error)
- simplified tcp connection handling (checking directly with QTcpSocket instead of indirect status variable
- removes unnecessary mutexes
- renamed generic "timer" objects to fftTimer / serverListUpdateTimer
